### PR TITLE
dPriority needs to reflect coins per day

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -624,7 +624,7 @@ public:
     {
         // Large (in bytes) low-priority (new, small-coin) transactions
         // need a fee.
-        return dPriority > COIN * 576 / 250;
+        return dPriority > COIN * 1440 / 250;
     }
 
 // Apply the effects of this transaction on the UTXO set represented by view


### PR DESCRIPTION
Value changed from 576 to 1440, 60 second block is 1440 blocks per day.